### PR TITLE
Allow case insensitive patterns

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,17 +29,13 @@ var extractParamsInFirstMatch = require('extract-params').extractParamsInFirstMa
 
 ## API
 
-* [`extractParams(str, pattern, [transform])`](#extractParams)
+* [`extractParams(str, pattern)`](#extractParams)
 * [`extractParamsInFirstMatch(str, patterns)`](#extractParamsInFirstMatch)
 
 <a name="extractParams"></a>
-### extractParams(str, pattern, [transform])
+### extractParams(str, pattern)
 
-Tests whether `str` matches the given parameterized `pattern`. If match is successful, it returns a hash of parameters and their values.
-
-Otherwise, `extractParams` returns `null`.
-
-An optional `transform` function can be passed to manipulate the extracted params. If `transform` returns `null`, the match fails. `transform` can be used, for example, to lowercase the values in `params`, or to validate them (return `null` if validation fails).
+Tests whether `str` matches the given parameterized [pattern](#patterns). If match is successful, it returns a hash of parameters and their values. Otherwise, `extractParams` returns `null`.
 
 The match is considered successful only if `str` matches the `pattern` at the start and at the end (see examples 2 and 3 below).
 
@@ -99,11 +95,13 @@ var params = extractParams(
 ```js
 var params = extractParams(
   '/users/1234/friends/456/photo',
-  '/users/:userId/friends/:friendId/photo',
-  function(params) {
-    var userId = parseInt(params.userId, 10);
-    
-    return userId >= 1 && userId <= 999 ? params : null;
+  {
+    pattern: '/users/:userId/friends/:friendId/photo',
+    transform: function(params) {
+      var userId = parseInt(params.userId, 10);
+
+      return userId >= 1 && userId <= 999 ? params : null;
+    }
   }
 );
 
@@ -118,7 +116,7 @@ var params = extractParams(
 <a name="extractParamsInFirstMatch"></a>
 ### extractParamsInFirstMatch(str, patterns)
 
-Tests whether `str` matches one of the parameterized `patterns`. Every pattern can have an optional `transform` function. If none of the `patterns` match, `extractParamsInFirstMatch` returns `null`. Otherwise, it returns the matching pattern index and its parameters.
+Tests whether `str` matches one of the parameterized [patterns](#patterns). If none of the `patterns` match, `extractParamsInFirstMatch` returns `null`. Otherwise, it returns the matching pattern index and its parameters.
 
 #### Example 1
 
@@ -202,6 +200,56 @@ var params = extractParamsInFirstMatch(
     
   because userId > 999
 */
+```
+
+<a name="patterns"></a>
+## Patterns
+
+The functions in this library operate on a `pattern` type.
+
+### Basic patterns
+
+In its simplest form, it is just a string, e.g. `/users/:userId/friends/:friendId/photo`.
+
+### Advanced patterns
+
+For more advanced patterns, an object can be provided instead.
+
+If the path is not case sensitive, you can define the `caseSensitive` option:
+
+```js
+{
+  pattern: `/users/:userId/friends/:friendId/photo`,
+  caseSensitive: false
+}
+```
+
+An optional `transform` function can be provided to manipulate the extracted params:
+
+For example, you can lowercase the values in `params`:
+
+```js
+{
+  pattern: '/albums/:albumName',
+  transform: function(params) {
+    return {
+      albumName: params.albumName.toLowerCase()
+    };
+  }
+}
+```
+
+If `transform` returns `null`, the match fails.
+
+For example, you can ensure params match a regular expression:
+
+```js
+{
+  pattern: '/albums/:albumName',
+  transform: function(params) {
+    return /[a-z0-9\-]/i.test(params.albumName) ? params : null;
+  }
+}
 ```
 
 ## Running Tests

--- a/lib/extractParams.js
+++ b/lib/extractParams.js
@@ -1,3 +1,6 @@
+var assign = require('lodash.assign');
+var isPlainObject = require('lodash.isplainobject');
+
 var paramRegex = /:[a-zA-Z]+/g;
 
 // https://developer.mozilla.org/en/docs/Web/JavaScript/Guide/Regular_Expressions#Using_Special_Characters
@@ -9,27 +12,36 @@ function identity(params) {
   return params;
 }
 
-module.exports = function extractParams(str, pattern, transform) {
+function normalisePattern(inputPattern) {
+  return isPlainObject(inputPattern) ?
+    assign({ caseSensitive: true }, inputPattern) :
+    { pattern: inputPattern, caseSensitive: true };
+}
+
+module.exports = function extractParams(str, inputPattern) {
+  var pattern = normalisePattern(inputPattern);
+
   if (typeof str !== 'string') {
     throw new Error('\'str\' must be a string');
     return null;
   }
 
-  if (typeof pattern !== 'string') {
+  if (typeof pattern.pattern !== 'string') {
     throw new Error('\'pattern\' must be a string');
     return null;
   }
 
-  if (typeof transform === 'undefined') {
-    transform = identity;
-  } else if (typeof transform !== 'function') {
+  if (typeof pattern.transform === 'undefined') {
+    pattern.transform = identity;
+  } else if (typeof pattern.transform !== 'function') {
     throw new Error('\'transform\' must be a function');
     return null;
   }
 
-  var valuesRegex = new RegExp('^' + pattern.split(paramRegex).map(function(patternPart) {
+  var regexFlags = pattern.caseSensitive ? '' : 'i';
+  var valuesRegex = new RegExp('^' + pattern.pattern.split(paramRegex).map(function(patternPart) {
     return escapeRegexCharacters(patternPart);
-  }).join('(.+)') + '$');
+  }).join('(.+)') + '$', regexFlags);
 
   var valuesMatch = str.match(valuesRegex);
 
@@ -37,17 +49,17 @@ module.exports = function extractParams(str, pattern, transform) {
     return null;
   }
 
-  var paramsMatch = pattern.match(paramRegex);
+  var paramsMatch = pattern.pattern.match(paramRegex);
 
   if (paramsMatch === null) {
-    return transform({});
+    return pattern.transform({});
   }
 
   var params = paramsMatch.map(function(param) {
     return param.slice(1); // remove leading ':'
   });
 
-  return transform(valuesMatch.slice(1).reduce(function(result, value, index) {
+  return pattern.transform(valuesMatch.slice(1).reduce(function(result, value, index) {
     result[params[index]] = value;
     return result;
   }, {}));

--- a/lib/extractParamsInFirstMatch.js
+++ b/lib/extractParamsInFirstMatch.js
@@ -14,7 +14,7 @@ module.exports = function extractParamsInFirstMatch(str, patterns) {
   var patternsCount = patterns.length;
 
   for (var i = 0; i < patternsCount; i++) {
-    var params = extractParams(str, patterns[i].pattern, patterns[i].transform);
+    var params = extractParams(str, patterns[i]);
 
     if (params !== null) {
       return {

--- a/package.json
+++ b/package.json
@@ -25,6 +25,10 @@
     "pattern matching",
     "pattern-matching"
   ],
+  "dependencies": {
+    "lodash.assign": "^3.2.0",
+    "lodash.isplainobject": "^3.2.0"
+  },
   "devDependencies": {
     "chai": "^3.4.1",
     "eslint": "^1.10.3",

--- a/test/extractParams.js
+++ b/test/extractParams.js
@@ -17,8 +17,10 @@ var testCases = [
   {
     should: 'throw an Error if transform is not a function',
     str: '/elm',
-    pattern: '/:language',
-    transform: {},
+    pattern: {
+      pattern: '/:language',
+      transform: {}
+    },
     throw: '\'transform\' must be a function'
   },
   {
@@ -48,17 +50,19 @@ var testCases = [
   {
     should: 'return use the transform function if there is match but the pattern has no parameters',
     str: 'react-is-awesome',
-    pattern: 'react-is-awesome',
-    transform: function(params) {
-      var newParams = {
-        mood: 'awesome'
-      };
+    pattern: {
+      pattern: 'react-is-awesome',
+      transform: function(params) {
+        var newParams = {
+          mood: 'awesome'
+        };
 
-      for (var param in params) {
-        newParams[param] = params[param];
+        for (var param in params) {
+          newParams[param] = params[param];
+        }
+
+        return newParams;
       }
-
-      return newParams;
     },
     result: {
       mood: 'awesome'
@@ -91,17 +95,27 @@ var testCases = [
     }
   },
   {
+    should: 'handle case insensitive patterns',
+    str: 'My-Name-Is-Misha',
+    pattern: { pattern: 'my-name-is-:name', caseSensitive: false },
+    result: {
+      name: 'Misha'
+    }
+  },
+  {
     should: 'transform the extracted params using the transform function',
     str: '/users/123/friends/456/photo',
-    pattern: '/users/:userId/friends/:friendId/photo',
-    transform: function(params) {
-      var newParams = {};
+    pattern: {
+      pattern: '/users/:userId/friends/:friendId/photo',
+      transform: function(params) {
+        var newParams = {};
 
-      for (var param in params) {
-        newParams[param] = '**' + params[param] + '**';
+        for (var param in params) {
+          newParams[param] = '**' + params[param] + '**';
+        }
+
+        return newParams;
       }
-
-      return newParams;
     },
     result: {
       userId: '**123**',
@@ -111,11 +125,13 @@ var testCases = [
   {
     should: 'fail the match if the transform function returns null',
     str: '/users/1234/friends/456/photo',
-    pattern: '/users/:userId/friends/:friendId/photo',
-    transform: function(params) {
-      var userId = parseInt(params.userId, 10);
+    pattern: {
+      pattern: '/users/:userId/friends/:friendId/photo',
+      transform: function(params) {
+        var userId = parseInt(params.userId, 10);
 
-      return userId >= 1 && userId <= 999 ? params : null;
+        return userId >= 1 && userId <= 999 ? params : null;
+      }
     },
     result: null
   }
@@ -124,7 +140,7 @@ var testCases = [
 describe('extractParams should', function() {
   testCases.forEach(function(testCase) {
     it(testCase.should, function() {
-      var fn = extractParams.bind(null, testCase.str, testCase.pattern, testCase.transform);
+      var fn = extractParams.bind(null, testCase.str, testCase.pattern);
 
       if (testCase.throw) {
         expect(fn).to.throw(testCase.throw);

--- a/test/extractParamsInFirstMatch.js
+++ b/test/extractParamsInFirstMatch.js
@@ -64,6 +64,35 @@ var testCases = [
     }
   },
   {
+    should: 'return the first match if the string has mixed case when patterns are not case sensitive',
+    str: '/UsErS/123',
+    patterns: [
+      { pattern: '/users/:userId/friends/:friendId/photo', caseSensitive: false },
+      { pattern: '/users/:userId/friends/:friendId', caseSensitive: false },
+      { pattern: '/users/:userId/friends', caseSensitive: false },
+      { pattern: '/users/:userId', caseSensitive: false },
+      { pattern: '/users', caseSensitive: false }
+    ],
+    result: {
+      patternIndex: 3,
+      params: {
+        userId: '123'
+      }
+    }
+  },
+  {
+    should: 'return null if the string has mixed case given patterns are case sensitive by default',
+    str: '/UsErS/123',
+    patterns: [
+      { pattern: '/users/:userId/friends/:friendId/photo' },
+      { pattern: '/users/:userId/friends/:friendId' },
+      { pattern: '/users/:userId/friends' },
+      { pattern: '/users/:userId' },
+      { pattern: '/users' }
+    ],
+    result: null
+  },
+  {
     should: 'use the transform function to return the first match',
     str: '/users/1234/friends/456',
     patterns: [


### PR DESCRIPTION
This is achieved by introducing a pattern type, which allows a unified approach to defining advanced patterns, including transform functions and case sensitivity as options.

Please note that this is a _breaking change_ to the API for `extractParams`, but I have documented this in the readme.
